### PR TITLE
Early return to avoid target duplication in React tutorial

### DIFF
--- a/extensions/custom-field/shopify.extension.toml
+++ b/extensions/custom-field/shopify.extension.toml
@@ -1,7 +1,7 @@
 # Learn more about configuring your checkout UI extension:
 # https://shopify.dev/api/checkout-extensions/checkout/configuration
 
-api_version = "2023-10"
+api_version = "2024-07"
 
 [[extensions]]
 name = "custom-field"

--- a/extensions/custom-field/src/Checkout.jsx
+++ b/extensions/custom-field/src/Checkout.jsx
@@ -7,6 +7,7 @@ import {
   useMetafield,
   Checkbox,
 } from "@shopify/ui-extensions-react/checkout";
+import { useDeliveryGroupListTarget } from "@shopify/ui-extensions-react/checkout";
 
 // [START custom-field.ext-index]
 // Set the entry point for the extension
@@ -36,6 +37,12 @@ function App() {
   // Set a function to handle updating a metafield
   const applyMetafieldsChange = useApplyMetafieldsChange();
   // [END custom-field.update-metafield]
+
+    // Guard against duplicate rendering of `shipping-option-list.render-after` UI extension for one-time purchase and subscription sections. This would cause an overwrite of the metafield value when calling `applyMetafieldsChange` from the duplicated section. Instead of guarding, another approach would be to namespace the metafield for one-time purchase and subscription.
+    const deliveryGroupList = useDeliveryGroupListTarget();
+    if (!deliveryGroupList || deliveryGroupList.groupType !== 'oneTimePurchase') {
+      return null;
+    }
 
   // Set a function to handle the Checkbox component's onChange event
   const handleChange = () => {


### PR DESCRIPTION
This PR edits the custom field React example found [here](https://shopify.dev/docs/apps/build/checkout/custom/fields/add?extension=react) in the docs. It adds an early return when the `groupType` is different than `'oneTimePurchase'`.

I tested it on my dev prod store and it works as expected. I've since removed the extension, but happy to add it back if reviewers are not feeling confident about it.

For context, this example/repo is referenced directly from `shopify/shopify-dev` code:
- here for `Checkout.jsx`: https://github.com/Shopify/shopify-dev/blob/main/content/apps/build/checkout/custom/fields/add.mdx?plain=1#L88
- here for `shopify.extension.toml`: https://github.com/Shopify/shopify-dev/blob/main/content/apps/build/checkout/custom/fields/add.mdx?plain=1#L68

We can also see it directly in the network request tab when accessing the example itself.

![Screenshot 2024-06-07 at 1 19 39 PM](https://github.com/Shopify/example-checkout--custom-field--react/assets/6304841/b520a294-99ab-4e76-80ea-e7ba969f8d44)
