### PR TITLE
Adjust comment related to guarding, to improve clarity

### DIFF
--- a/extensions/custom-field/src/Checkout.jsx
+++ b/extensions/custom-field/src/Checkout.jsx
@@ -38,11 +38,12 @@ function App() {
   const applyMetafieldsChange = useApplyMetafieldsChange();
   // [END custom-field.update-metafield]
 
-    // Guard against duplicate rendering of `shipping-option-list.render-after` UI extension for one-time purchase and subscription sections. This would cause an overwrite of the metafield value when calling `applyMetafieldsChange` from the duplicated section. Instead of guarding, another approach would be to namespace the metafield for one-time purchase and subscription.
-    const deliveryGroupList = useDeliveryGroupListTarget();
-    if (!deliveryGroupList || deliveryGroupList.groupType !== 'oneTimePurchase') {
-      return null;
-    }
+  // Guard against duplicate rendering of `shipping-option-list.render-after` target for one-time purchase and subscription sections. Calling `applyMetafieldsChange()` on the same namespace-key pair from duplicated extensions would otherwise cause an overwrite of the metafield value.
+  // Instead of guarding, another approach would be to prefix the metafield key when calling `applyMetafieldsChange()`. The `deliveryGroupList`'s `groupType` could be used to such effect.
+  const deliveryGroupList = useDeliveryGroupListTarget();
+  if (!deliveryGroupList || deliveryGroupList.groupType !== 'oneTimePurchase') {
+    return null;
+  }
 
   // Set a function to handle the Checkbox component's onChange event
   const handleChange = () => {


### PR DESCRIPTION
Following [feedback given in the custom field tutorial](https://github.com/Shopify/shopify-dev/pull/45342#discussion_r1635293312), we adjust this example too to improve clarity of one of the code comments.

While at it, we also fix the problematic indentation of the code just below this comment.